### PR TITLE
Update varchar length in wordfilter_* tables

### DIFF
--- a/fullDB/wordfilter_character_names.sql
+++ b/fullDB/wordfilter_character_names.sql
@@ -5,8 +5,8 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 
 CREATE TABLE IF NOT EXISTS `wordfilter_character_names` (
-  `regex_match` varchar(500) NOT NULL,
-  `regex_ignore_if_matched` varchar(500) NOT NULL DEFAULT '',
+  `regex_match` varchar(300) NOT NULL,
+  `regex_ignore_if_matched` varchar(300) NOT NULL DEFAULT '',
   PRIMARY KEY (`regex_match`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci COMMENT='Wordfilter System';
 

--- a/fullDB/wordfilter_chat.sql
+++ b/fullDB/wordfilter_chat.sql
@@ -5,8 +5,8 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 
 CREATE TABLE IF NOT EXISTS `wordfilter_chat` (
-  `regex_match` varchar(500) NOT NULL,
-  `regex_ignore_if_matched` varchar(500) NOT NULL DEFAULT '',
+  `regex_match` varchar(300) NOT NULL,
+  `regex_ignore_if_matched` varchar(300) NOT NULL DEFAULT '',
   PRIMARY KEY (`regex_match`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci COMMENT='Wordfilter System';
 

--- a/updates/20191114-00_wordfilter.sql
+++ b/updates/20191114-00_wordfilter.sql
@@ -1,0 +1,9 @@
+/*
+Length of index should not be more than 1000 bytes to avoid "Specified key was too long; max key length is 1000 bytes" error.
+*/
+
+ALTER TABLE `wordfilter_character_names` MODIFY `regex_match` varchar(300);
+ALTER TABLE `wordfilter_character_names` MODIFY `regex_ignore_if_matched` varchar(300);
+ALTER TABLE `wordfilter_chat` MODIFY `regex_match` varchar(300);
+ALTER TABLE `wordfilter_chat` MODIFY `regex_ignore_if_matched` varchar(300);
+


### PR DESCRIPTION
Trying to import wordflter_* tables from fullDB folder gives "Specified key was too long; max key length is 1000 bytes" error. Reducing the varchar size from 500 to 300 fixes it.
Apparently in UTF8 varchar(500) is actually 1500 bytes.